### PR TITLE
Minor text overflow style fix

### DIFF
--- a/popup/add.html
+++ b/popup/add.html
@@ -5,12 +5,12 @@
     <meta charset="utf-8">
     <style>
 
-html, body {
-     width: 200px;
-     font-size: 10pt;
-     font-family: "Segoe UI", sans-serif;
-     background: darkslategrey;
-     margin: 0;
+    html, body {
+      width: 200px;
+      font-size: 10pt;
+      font-family: "Segoe UI", sans-serif;
+      background: darkslategrey;
+      margin: 0;
     }
 
     .button {
@@ -26,6 +26,8 @@ html, body {
       text-align:center;
       color: white;
       padding: 8px 5px;
+      white-space: nowrap;
+      overflow: hidden;
       text-overflow: ellipsis;
     }
 

--- a/popup/no.html
+++ b/popup/no.html
@@ -7,16 +7,17 @@
     <style>
 
     html, body {
-        font-size: 10pt;
-        font-family: "Segoe UI", sans-serif;
-        background-image: radial-gradient( circle 1224px at 10.6% 8.8%,  rgba(255,255,255,1) 0%, rgba(153,202,251,1) 100.2% );         
+      font-size: 10pt;
+      font-family: "Segoe UI", sans-serif;
+      background-image: radial-gradient( circle 1224px at 10.6% 8.8%,  rgba(255,255,255,1) 0%, rgba(153,202,251,1) 100.2% );         
     }
-
 
     header, footer {
       margin: 0;
       text-align:center;
       padding: 8px 5px;
+      white-space: nowrap;
+      overflow: hidden;
       text-overflow: ellipsis;
       font-size:60pt;
     }
@@ -46,6 +47,7 @@
     .btn {
       text-decoration: none;
     }
+
     </style>
     <script src="no.js" type="module"></script>
 </head>


### PR DESCRIPTION
Making `text-overflow: ellipsis;` work as expected on header/footer (specially on footer with big domain names).